### PR TITLE
Add friendly alert for NSError

### DIFF
--- a/NSErrorX.h
+++ b/NSErrorX.h
@@ -29,4 +29,9 @@
  */
 + (instancetype)friendlyErrorWithDomain:(NSString *)domain andCode:(NSInteger)code;
 
+/**
+ *  Shows alert with localizedFailureReason or localizedDescription
+ */
+- (void)showAlertView;
+
 @end

--- a/NSErrorX.m
+++ b/NSErrorX.m
@@ -1093,4 +1093,21 @@
                                         } : nil];
 }
 
+
+-(void)showAlertView
+{
+    [self showAlertViewWithTitle:@"Error" andMessage:self.localizedFailureReason ?: self.localizedDescription];
+}
+
+-(void)showAlertViewWithTitle:(NSString *)title andMessage:(NSString *)message
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIAlertView* alertView = [[UIAlertView alloc] initWithTitle:title
+                                                            message:message
+                                                           delegate:nil
+                                                  cancelButtonTitle:NSLocalizedString(@"OK", nil) otherButtonTitles:nil, nil];
+        [alertView show];
+    });
+}
+
 @end

--- a/NSErrorX.m
+++ b/NSErrorX.m
@@ -1,6 +1,7 @@
 #import "NSErrorX.h"
 
 #import "NSDictionaryX.h"
+#import "MacroX.h"
 
 #import <Foundation/FoundationErrors.h>
 #import <CoreData/CoreDataErrors.h>
@@ -1096,17 +1097,13 @@
 
 -(void)showAlertView
 {
-    [self showAlertViewWithTitle:@"Error" andMessage:self.localizedFailureReason ?: self.localizedDescription];
+    [self showAlertViewWithTitle:@"Error" andMessage:self.localizedFailureReason ?: self.friendlyLocalizedDescription];
 }
 
 -(void)showAlertViewWithTitle:(NSString *)title andMessage:(NSString *)message
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        UIAlertView* alertView = [[UIAlertView alloc] initWithTitle:title
-                                                            message:message
-                                                           delegate:nil
-                                                  cancelButtonTitle:NSLocalizedString(@"OK", nil) otherButtonTitles:nil, nil];
-        [alertView show];
+        SHOW_ALERT(title, message, nil, NSLocalizedString(@"OK", nil), nil);
     });
 }
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Precompile definitions of some commonly-used boilerplate code.
 	//create an NSError object with given domain, code and userInfo with a friendly human-readable localized description for known domains and codes
 	+ (instancetype)friendlyErrorWithDomain:(NSString *)domain andCode:(NSInteger)code;
 
+    // Shows alert with localizedFailureReason or localizedDescription
+    - (void)showAlertView;
+
 #### NSException
 
     - (NSArray *)backtrace;  //pretty-formatted stack trace


### PR DESCRIPTION
Update old pull request. User-friendly alert for NSError.

Usage example:

```
NSError *error;
NSArray * oldObjects = [context executeFetchRequest:fetchRequest error:&error];

NSArray * arrayToIterate = [oldObjects copy];

if (error) {
    [error showAlertView];
    return;
}
```
